### PR TITLE
Use device name instead of device type 

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,11 +39,11 @@ class App extends Homey.App {
                 db.host = data.addresses[0];
 
                 for (let key in data.txt) {
-                    if (data.txt[key].indexOf('md=') > -1) {
-                        db.name = data.txt[key].replace('md=', '');
-                    }
                     if (data.txt[key].indexOf('fn=') > -1) {
-                        db.description = data.txt[key].replace('fn=', '');
+                        db.name = data.txt[key].replace('fn=', '');
+                    }
+                    if (data.txt[key].indexOf('md=') > -1) {
+                        db.description = data.txt[key].replace('md=', '');
                     }
                 }
 


### PR DESCRIPTION
This changes the device name in the list to the actual device name e.g. `Livingroom` instead of `Google Home Mini`.

I own multiple google home minis and only the last one was rendered because it indexed on `Google Home Mini`. I also think the showing the actual device name is better UX than `Google Home Mini`

Thanks for the work, I'm already enjoying it when somebody presses the doorbell :)

![screenshot_20190129-201945_homey](https://user-images.githubusercontent.com/7521173/51934276-76e91780-2403-11e9-9681-d128c9aeafd7.jpg)
